### PR TITLE
Fix wrong number of arguments when trying to stub methods with rspec

### DIFF
--- a/lib/literate_randomizer.rb
+++ b/lib/literate_randomizer.rb
@@ -42,7 +42,7 @@ module LiterateRandomizer
     end
 
     # correctly mirrors method_missing
-    def respond_to?(method)
+    def respond_to?(method, include_private = false)
       super || global.respond_to?(method)
     end
   end


### PR DESCRIPTION
When I try to stub sentence in rspec like
```ruby
  allow(LiterateRandomizer).to receive(:sentence).and_return 'Thrusting in the place'
```

it fails with error `wrong number of arguments (2 for 1)`

This fix solves the problem